### PR TITLE
Mouse Down Color Bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,7 @@ function createMap()
         {
             //console.log("Mouse Move Hit");
             const squareUnderMouse = document.elementFromPoint(event.clientX, event.clientY);
+            selectedColor = pickedColor;
             if (squareUnderMouse.classList.contains('square'))
             {
                 const computedColor = window.getComputedStyle(squareUnderMouse).getPropertyValue('background-color');


### PR DESCRIPTION
# Issue
 - When the mouse button is held down for click and drag, if the color has been changed more than once, then sometimes dragging over adjacent tiles resulted in converting the state to the older color (first color selected).
 
 # Solution
  - Ensure the selectedColor is updated to the picked color during the event listener of mousemove.